### PR TITLE
Fix trigonometric functions

### DIFF
--- a/src/engine/Engine.hpp
+++ b/src/engine/Engine.hpp
@@ -16,6 +16,8 @@
 #include "SpriteMessage.hpp"
 #include "Variable.hpp"
 
+static const double pi = std::acos(-1);  // TODO: Use std::numbers::pi in C++20
+
 namespace EngineFunctions {
 class Engine {
 public:

--- a/src/engine/Reporters.cpp
+++ b/src/engine/Reporters.cpp
@@ -71,12 +71,12 @@ Value EngineFunctions::Engine::compute_reporter(std::string opid, ScratchTarget*
         if (mathop == "floor") return std::floor(in.get_number());
         if (mathop == "ceiling") return std::ceil(in.get_number());
         if (mathop == "sqrt") return std::sqrt(in.get_number());
-        if (mathop == "sin") return std::sin(in.get_number());
-        if (mathop == "cos") return std::cos(in.get_number());
-        if (mathop == "tan") return std::tan(in.get_number());
-        if (mathop == "asin") return std::asin(in.get_number());
-        if (mathop == "acos") return std::acos(in.get_number());
-        if (mathop == "atan") return std::atan(in.get_number());
+        if (mathop == "sin") return std::sin(in.get_number() * pi / 180);
+        if (mathop == "cos") return std::cos(in.get_number() * pi / 180);
+        if (mathop == "tan") return std::tan(in.get_number() * pi / 180);
+        if (mathop == "asin") return std::asin(in.get_number() * 180 / pi);
+        if (mathop == "acos") return std::acos(in.get_number() * 180 / pi);
+        if (mathop == "atan") return std::atan(in.get_number() * 180 / pi);
         if (mathop == "ln") return std::log(in.get_number());
         if (mathop == "log") return std::log10(in.get_number());
         if (mathop == "e ^") return std::exp(in.get_number());


### PR DESCRIPTION
The trigonometric functions in C++ use radians, not degrees.

`std::numbers::pi` can be used for pi in C++20.